### PR TITLE
Add atomic notification handling for queue management

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,6 +19,7 @@ export interface QueueItem {
   position: number;
   queueType: 'confissoes' | 'direcao-espiritual';
   createdAt: string;
+  almostThereNotificationSent?: boolean; // Campo para controlar notificações duplicadas
 }
 
 export interface CalledPerson {


### PR DESCRIPTION
- Introduced a new function to send 'almost-there' notifications atomically, preventing race conditions when multiple admins are sending notifications.
- Updated the QueueItem interface to include a flag for tracking if the notification has already been sent.
- Refactored the processQueueUpdate function to utilize the new atomic notification function, enhancing reliability in notification delivery.